### PR TITLE
Update torrent-get-url.query.ts

### DIFF
--- a/projects/plugin/src/plugin/queries/torrents/torrent-get-url.query.ts
+++ b/projects/plugin/src/plugin/queries/torrents/torrent-get-url.query.ts
@@ -39,6 +39,11 @@ export class TorrentGetUrlQuery {
         if (_html.match(/href=["|']?(magnet[^"|']+)/)) {
           return _html.match(/href=["|']?(magnet[^"|']+)/)[1];
         }
+        if (_html.match(/>([a-zA-Z0-9]{40})</)) {
+        let magnetHeader = ('magnet:?xt=urn:btih:');
+        let infoHash = _html.match(/>([a-zA-Z0-9]{40})</)[1];
+        return magnetHeader+infoHash;
+        }
         if (_html.match(/http(.*?).torrent["\']/)) {
           return _html.match(/http(.*?).torrent["\']/).shift();
         }


### PR DESCRIPTION
If there is no magnet link, search for an infohash.  If there is an infohash, return this as a magnet link to be cache checked.
It searches for a 40 character long string (a-zA-Z0-9) between a > and a < then adds the magnet header (magnet:?xt=urn:btih:)